### PR TITLE
Add role-based permissions for activity management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Role-based authorization for management operations
 
 ## Getting Started
 
@@ -31,6 +32,26 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                     |
+| POST   | `/activities`                                                     | Create activity (organizer/admin only)                             |
+| PATCH  | `/activities/{activity_name}`                                     | Update activity (organizer/admin only)                             |
+| DELETE | `/activities/{activity_name}`                                     | Delete activity (organizer/admin only)                             |
+
+## Access Rules
+
+The API uses a lightweight mock auth header, `X-User-Role`, with these valid values:
+
+- `student`
+- `organizer`
+- `admin`
+
+Rules:
+
+- If `X-User-Role` is omitted, the API treats the request as `student`.
+- `student` can list activities and sign up/unregister.
+- `organizer` and `admin` can create, update, and delete activities.
+- Invalid role values return `401`.
+- Authenticated roles without sufficient permissions return `403`.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,9 +5,12 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from typing import Literal
+
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
 
@@ -78,6 +81,44 @@ activities = {
 }
 
 
+Role = Literal["student", "organizer", "admin"]
+VALID_ROLES = {"student", "organizer", "admin"}
+
+
+class ActivityCreate(BaseModel):
+    name: str
+    description: str
+    schedule: str
+    max_participants: int
+
+
+class ActivityUpdate(BaseModel):
+    description: str | None = None
+    schedule: str | None = None
+    max_participants: int | None = None
+
+
+def get_current_role(x_user_role: str | None = Header(default=None, alias="X-User-Role")) -> Role:
+    """Read role from header for a lightweight auth simulation."""
+    if x_user_role is None:
+        return "student"
+
+    role = x_user_role.strip().lower()
+    if role not in VALID_ROLES:
+        raise HTTPException(status_code=401, detail="Invalid role in X-User-Role header")
+
+    return role
+
+
+def require_role(*allowed_roles: Role):
+    def _dependency(role: Role = Depends(get_current_role)) -> Role:
+        if role not in allowed_roles:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return role
+
+    return _dependency
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -86,6 +127,76 @@ def root():
 @app.get("/activities")
 def get_activities():
     return activities
+
+
+@app.post("/activities")
+def create_activity(
+    activity: ActivityCreate,
+    _: Role = Depends(require_role("organizer", "admin")),
+):
+    """Create a new activity (organizer/admin only)."""
+    activity_name = activity.name.strip()
+    if not activity_name:
+        raise HTTPException(status_code=400, detail="Activity name cannot be empty")
+
+    if activity.max_participants <= 0:
+        raise HTTPException(status_code=400, detail="max_participants must be greater than 0")
+
+    if activity_name in activities:
+        raise HTTPException(status_code=400, detail="Activity already exists")
+
+    activities[activity_name] = {
+        "description": activity.description,
+        "schedule": activity.schedule,
+        "max_participants": activity.max_participants,
+        "participants": []
+    }
+
+    return {"message": f"Created activity {activity_name}", "activity": activities[activity_name]}
+
+
+@app.patch("/activities/{activity_name}")
+def update_activity(
+    activity_name: str,
+    activity_update: ActivityUpdate,
+    _: Role = Depends(require_role("organizer", "admin")),
+):
+    """Update an existing activity (organizer/admin only)."""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if activity_update.description is not None:
+        activity["description"] = activity_update.description
+
+    if activity_update.schedule is not None:
+        activity["schedule"] = activity_update.schedule
+
+    if activity_update.max_participants is not None:
+        if activity_update.max_participants < len(activity["participants"]):
+            raise HTTPException(
+                status_code=400,
+                detail="max_participants cannot be below current participant count"
+            )
+        if activity_update.max_participants <= 0:
+            raise HTTPException(status_code=400, detail="max_participants must be greater than 0")
+        activity["max_participants"] = activity_update.max_participants
+
+    return {"message": f"Updated {activity_name}", "activity": activity}
+
+
+@app.delete("/activities/{activity_name}")
+def delete_activity(
+    activity_name: str,
+    _: Role = Depends(require_role("organizer", "admin")),
+):
+    """Delete an existing activity (organizer/admin only)."""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    del activities[activity_name]
+    return {"message": f"Deleted {activity_name}"}
 
 
 @app.post("/activities/{activity_name}/signup")

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,98 @@
+from fastapi.testclient import TestClient
+
+from src.app import app
+
+
+client = TestClient(app)
+
+
+def test_student_can_list_activities():
+    response = client.get("/activities", headers={"X-User-Role": "student"})
+    assert response.status_code == 200
+
+
+def test_student_can_signup_and_unregister():
+    email = "rbac.student@mergington.edu"
+
+    signup = client.post(
+        "/activities/Chess%20Club/signup",
+        params={"email": email},
+        headers={"X-User-Role": "student"},
+    )
+    assert signup.status_code == 200
+
+    unregister = client.delete(
+        "/activities/Chess%20Club/unregister",
+        params={"email": email},
+        headers={"X-User-Role": "student"},
+    )
+    assert unregister.status_code == 200
+
+
+def test_student_cannot_create_activity():
+    response = client.post(
+        "/activities",
+        json={
+            "name": "Science Club",
+            "description": "Experiments and STEM projects",
+            "schedule": "Mondays, 3:30 PM - 4:30 PM",
+            "max_participants": 12,
+        },
+        headers={"X-User-Role": "student"},
+    )
+    assert response.status_code == 403
+
+
+def test_organizer_can_create_and_update_activity():
+    create_response = client.post(
+        "/activities",
+        json={
+            "name": "Organizer Club",
+            "description": "Club created by organizer",
+            "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+        },
+        headers={"X-User-Role": "organizer"},
+    )
+    assert create_response.status_code == 200
+
+    update_response = client.patch(
+        "/activities/Organizer Club",
+        json={"max_participants": 14},
+        headers={"X-User-Role": "organizer"},
+    )
+    assert update_response.status_code == 200
+
+
+def test_admin_can_delete_activity():
+    create_response = client.post(
+        "/activities",
+        json={
+            "name": "Admin Delete Club",
+            "description": "Temporary activity for delete validation",
+            "schedule": "Fridays, 3:30 PM - 4:30 PM",
+            "max_participants": 8,
+        },
+        headers={"X-User-Role": "admin"},
+    )
+    assert create_response.status_code == 200
+
+    delete_response = client.delete(
+        "/activities/Admin Delete Club",
+        headers={"X-User-Role": "admin"},
+    )
+    assert delete_response.status_code == 200
+
+
+def test_invalid_role_returns_401():
+    response = client.post(
+        "/activities",
+        json={
+            "name": "Invalid Role Club",
+            "description": "Should fail",
+            "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+        },
+        headers={"X-User-Role": "teacher"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add mock header-based role authentication via `X-User-Role`
- enforce authorization for activity management endpoints (`POST /activities`, `PATCH /activities/{activity_name}`, `DELETE /activities/{activity_name}`)
- keep student access for list/signup/unregister flows
- document role rules and status code behavior in `src/README.md`
- add RBAC tests covering allowed and denied role scenarios

## Role behavior
- default role without header: `student`
- valid roles: `student`, `organizer`, `admin`
- invalid role header -> `401`
- insufficient role on protected endpoints -> `403`

## Notes
- I attempted to run tests with `python -m pytest -q`, but terminal output in this environment is not returning command logs, so test output could not be confirmed in-session.